### PR TITLE
feat: Add clear tag filters button to Notes view

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,6 +199,11 @@
         "icon": "$(tag)"
       },
       {
+        "command": "noted.clearTagFilters",
+        "title": "Noted: Clear Tag Filters",
+        "icon": "$(clear-all)"
+      },
+      {
         "command": "noted.sortTagsByName",
         "title": "Noted: Sort Tags by Name",
         "icon": "$(sort-precedence)"
@@ -290,6 +295,11 @@
           "command": "noted.showCalendar",
           "when": "view == notedView",
           "group": "navigation@5"
+        },
+        {
+          "command": "noted.clearTagFilters",
+          "when": "view == notedView && noted.hasActiveTagFilters",
+          "group": "navigation@6"
         },
         {
           "command": "noted.showStats",

--- a/src/providers/notesTreeProvider.ts
+++ b/src/providers/notesTreeProvider.ts
@@ -74,6 +74,9 @@ export class NotesTreeProvider implements vscode.TreeDataProvider<TreeItem>, vsc
             }
         });
 
+        // Update context variable for conditional UI elements
+        vscode.commands.executeCommand('setContext', 'noted.hasActiveTagFilters', this.activeFilters.size > 0);
+
         this.refresh();
     }
 
@@ -83,6 +86,10 @@ export class NotesTreeProvider implements vscode.TreeDataProvider<TreeItem>, vsc
     clearTagFilters(): void {
         this.activeFilters.clear();
         this.filteredNotePaths.clear();
+
+        // Update context variable for conditional UI elements
+        vscode.commands.executeCommand('setContext', 'noted.hasActiveTagFilters', false);
+
         this.refresh();
     }
 


### PR DESCRIPTION
Added a clear filters button that appears in the Notes view title bar when tag filters are active. This provides an easy way to reset filtering without having to manually remove tags.

Changes:
- Added 'noted.clearTagFilters' command to package.json with clear-all icon
- Added button to Notes view title that only shows when filters are active
- Updated notesTreeProvider to set 'noted.hasActiveTagFilters' context variable
- Context variable automatically updates when filters are set or cleared

The button provides immediate visual feedback that filters are active and offers a one-click solution to clear them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)