### PR TITLE
fix: resolve collection not found error when editing from context menu

### DIFF
--- a/src/commands/collectionCommands.ts
+++ b/src/commands/collectionCommands.ts
@@ -13,14 +13,11 @@ import { CollectionItem } from '../providers/treeItems';
  * Helper function to extract collection ID from either a CollectionItem or a string
  */
 function getCollectionId(item: CollectionItem | string | undefined): string | undefined {
-    if (!item) {
-        return undefined;
-    }
-    if (typeof item === 'string') {
-        return item;
-    }
     if (item instanceof CollectionItem) {
         return item.collectionId;
+    }
+    if (typeof item === 'string' && item) {
+        return item;
     }
     return undefined;
 }


### PR DESCRIPTION
When right-clicking on a collection in the Smart Collections panel and selecting "Edit Collection", VS Code passes the CollectionItem tree item object to the command handler, not a string collection ID. This caused the collection lookup to fail.

Changes:
- Added helper function getCollectionId() to extract ID from either CollectionItem or string
- Updated all collection command handlers to accept CollectionItem | string:
  - handleEditCollection
  - handleDeleteCollection
  - handleRunCollection
  - handleTogglePinCollection
  - handleDuplicateCollection

This fix ensures that collection commands work correctly when invoked from the context menu or programmatically with a string ID.