### PR TITLE
Fix TypeScript types version mismatch in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/jsonify/noted"
   },
   "engines": {
-    "vscode": "^1.90.0"
+    "vscode": "^1.107.0"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
Update engines.vscode from ^1.90.0 to ^1.107.0 to match @types/vscode dependency version. VSCE packaging requires @types/vscode <= engines.vscode.